### PR TITLE
fix Users Get by Username --> .id to .user_id

### DIFF
--- a/docs/runtime-code-function-reference.md
+++ b/docs/runtime-code-function-reference.md
@@ -2986,7 +2986,7 @@ _Example_
     local users = nk.users_get_username(usernames)
     for _, u in ipairs(users)
     do
-      local message = string.format("id: %q, displayname: %q", u.id, u.display_name)
+      local message = string.format("id: %q, displayname: %q", u.user_id, u.display_name)
       nk.logger_info(message)
     end
     ```


### PR DESCRIPTION
Sorry if wrong, but today I tried out the lua nk.users_get_username(usernames) and I got nil for the .id, but it worked fine when I switched to .user_id. Not sure if same applies to Go